### PR TITLE
7-add-saturation-brightness-sliders-to-raster

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -80,7 +80,10 @@
                 "url_wmts"             : {"type": {"text":true}},
                 "url_wmts_show"        : {"type": {"bool":true}},
                 "url_tile_arcgis"      : {"type": {"text":true}},
-                "url_tile_arcgis_show" : {"type": {"bool":true}}
+                "url_tile_arcgis_show" : {"type": {"bool":true}},
+
+                "osm_brightness"       :{"type": {"numeric":true}},
+                "osm_greyscale"        :{"type": {"numeric":true}}
             }
         },
         "map_behaviour": {

--- a/src/linref.ts
+++ b/src/linref.ts
@@ -97,7 +97,7 @@ export async function batch_requests(
             }
         );
     }catch(e){
-        throw new BatchRequestFetchError(`BatchRequestFetchError(${e.message.slice(0,20)})`,{cause:e})
+        throw new BatchRequestFetchError(`BatchRequestFetchError(${e.message})`,{cause:e})
     }
     if (!response.ok) {
         throw new BatchRequestResponseError(`BatchRequestResponseError(${response.status.toString()},${response.statusText})`,{cause:response})

--- a/src/nickmap/NickMap.tsx
+++ b/src/nickmap/NickMap.tsx
@@ -95,6 +95,9 @@ export function NickMap(props:NickMapProps){
     const map_root_ref               = useRef<HTMLDivElement>();
     const layer_state_road_ticks_ref = useRef<VectorLayer<VectorSource> | null>(null);
 
+    // ================
+    // DRAG INTERACTION
+    // ================
     const drag_interaction_ref       = useRef<DragBox>((()=>{
         let result = new DragBox({
             condition:local_platformModifierKeyOnly,
@@ -106,8 +109,16 @@ export function NickMap(props:NickMapProps){
     useEffect(()=>{
         drag_interaction_ref.current.setActive(props.allow_drag_box_selection)
     },[props.allow_drag_box_selection])
-    
+
+    // ==================
+    // SELECT INTERACTION
+    // ==================
     const select_interaction_ref     = useRef<Select | null>(null)
+
+
+    // ==========
+    // MAP OBJECT
+    // ==========
     const map_ref = useRef(new OpenLayersMap({
         controls:[
             new Rotate(),
@@ -119,12 +130,7 @@ export function NickMap(props:NickMapProps){
         })
     }));
 
-    // ===============================
-    // CLEAR SELECTION ON EVERY UPDATE
-    // ===============================
-    if(select_interaction_ref.current){
-        select_interaction_ref.current.getFeatures().clear();
-    }
+
     // =====
     // MOUNT
     // =====

--- a/src/nickmap/hooks/useRefFactory.ts
+++ b/src/nickmap/hooks/useRefFactory.ts
@@ -1,0 +1,11 @@
+import { MutableRefObject, useRef } from "react";
+
+
+
+export function useRefFactory<T>(factory_function:()=>T): MutableRefObject<T>{
+    const result = useRef<T | null>(null);
+    if(result.current === null){
+        result.current = factory_function()
+    }
+    return result as MutableRefObject<T>
+}

--- a/src/nickmap/layers/TileLayerMonkeyPatchedBrightnessGreyscale.ts
+++ b/src/nickmap/layers/TileLayerMonkeyPatchedBrightnessGreyscale.ts
@@ -1,0 +1,22 @@
+import TileLayer from "ol/layer/Tile";
+import TileSource from "ol/source/Tile";
+
+export type TileLayerMonkeyPatchedBrightnessGreyscale<T extends TileSource> = TileLayer<T> & { __BRIGHTNESS: number; __GREYSCALE: number; };
+export function monkey_patch_brightness_greyscale_layer<T extends TileSource>(layer: TileLayer<T>): TileLayerMonkeyPatchedBrightnessGreyscale<T> {
+    (layer as TileLayerMonkeyPatchedBrightnessGreyscale<T>).__BRIGHTNESS = 60;
+    (layer as TileLayerMonkeyPatchedBrightnessGreyscale<T>).__GREYSCALE = 80;
+    layer.on('prerender', function (evt) {
+        const self = (layer as TileLayerMonkeyPatchedBrightnessGreyscale<T>);
+        const brightness = self.__BRIGHTNESS;
+        const greyscale  = self.__GREYSCALE;
+        
+        (evt.context as CanvasRenderingContext2D).filter =
+            `brightness(${brightness}%) grayscale(${greyscale})`;
+    });
+    layer.on('postrender', function (evt) {
+        (evt.context as CanvasRenderingContext2D).filter
+            = "none";
+    });
+    return layer as TileLayerMonkeyPatchedBrightnessGreyscale<T>;
+
+}

--- a/src/nickmap/layers/arcgis_rest.ts
+++ b/src/nickmap/layers/arcgis_rest.ts
@@ -1,6 +1,8 @@
 import { TileArcGISRest } from "ol/source";
 import TileLayer from "ol/layer/Tile";
-export const layer_arcgis_rest:TileLayer<TileArcGISRest> = new TileLayer({
+import { monkey_patch_brightness_greyscale_layer } from "./TileLayerMonkeyPatchedBrightnessGreyscale";
+
+export const layer_arcgis_rest = monkey_patch_brightness_greyscale_layer(new TileLayer({
     visible:false,
     source:new TileArcGISRest({})
-});
+}));

--- a/src/nickmap/layers/open_street_map.ts
+++ b/src/nickmap/layers/open_street_map.ts
@@ -1,18 +1,10 @@
 import TileLayer from "ol/layer/Tile";
 import XYZ from 'ol/source/XYZ';
+import {monkey_patch_brightness_greyscale_layer} from './TileLayerMonkeyPatchedBrightnessGreyscale';
 
-export const layer_open_street_map = new TileLayer({
+export const layer_open_street_map = monkey_patch_brightness_greyscale_layer(new TileLayer({
     source: new XYZ({
         url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
         //crossOrigin: "anonymous",
-    }),
-});
-
-layer_open_street_map.on('prerender', function (evt) {
-    (evt.context as CanvasRenderingContext2D).filter
-        = "brightness(90%) grayscale(30%)";
-});
-layer_open_street_map.on('postrender', function (evt) {
-    (evt.context as CanvasRenderingContext2D).filter
-        = "none";
-});
+    })
+}));

--- a/src/nickmap/layers/road_network.ts
+++ b/src/nickmap/layers/road_network.ts
@@ -109,16 +109,16 @@ function state_road_vector_layer_style_function(feature, resolution) {
 }
 
 
-function other_road_vector_layer_style_function(feature, resolution) {
-	let result =  road_network_styles[feature.get("NETWORK_TYPE")] ?? road_network_styles["DEFAULT"];
-	if (resolution < 0.8) {
-		let stl = road_name_text_style.clone();
-		stl.setText(feature.get("ROAD_NAME"))
-		result = result.clone()
-		result.setText(stl)
-	}
-	return result;
-}
+// function other_road_vector_layer_style_function(feature, resolution) {
+// 	let result =  road_network_styles[feature.get("NETWORK_TYPE")] ?? road_network_styles["DEFAULT"];
+// 	if (resolution < 0.8) {
+// 		let stl = road_name_text_style.clone();
+// 		stl.setText(feature.get("ROAD_NAME"))
+// 		result = result.clone()
+// 		result.setText(stl)
+// 	}
+// 	return result;
+// }
 
 
 
@@ -171,13 +171,21 @@ let custom_renderer_with_SLK_ticks:(map:Map)=>RenderFunction = (map:Map) => (_pi
 		//ticks = linestring_ticks(mls, slk_from, slk_to, 0.01, 10, canvas_size_x/pixle_ratio, canvas_size_y/pixle_ratio);
 		ticks = linestring_ticks(mls, slk_from, slk_to, 0.01, 10, canvas_size_x, canvas_size_y, decimal_figures);
 	} else if (state.resolution < 4) {
-		decimal_figures = 0
+		decimal_figures = 1
 		//ticks = linestring_ticks(mls, slk_from, slk_to, 0.1, 10, canvas_size_x/pixle_ratio, canvas_size_y/pixle_ratio);
-		ticks = linestring_ticks(mls, slk_from, slk_to, 0.1, 10, canvas_size_x, canvas_size_y, decimal_figures);
-	} else {
+		ticks = linestring_ticks(mls, slk_from, slk_to, 0.1, 5, canvas_size_x, canvas_size_y, decimal_figures);
+	} else if(state.resolution < 15 ) {
 		decimal_figures = 0
 		//ticks = linestring_ticks(mls, slk_from, slk_to, 0.1, 10, canvas_size_x/pixle_ratio, canvas_size_y/pixle_ratio);
 		ticks = linestring_ticks(mls, slk_from, slk_to, 1, 1, canvas_size_x, canvas_size_y, decimal_figures);
+	} else if(state.resolution < 80 ){
+		decimal_figures = 0
+		//ticks = linestring_ticks(mls, slk_from, slk_to, 0.1, 10, canvas_size_x/pixle_ratio, canvas_size_y/pixle_ratio);
+		ticks = linestring_ticks(mls, slk_from, slk_to, 10, 1, canvas_size_x, canvas_size_y, decimal_figures);
+	} else {
+		decimal_figures = 0
+		//ticks = linestring_ticks(mls, slk_from, slk_to, 0.1, 10, canvas_size_x/pixle_ratio, canvas_size_y/pixle_ratio);
+		ticks = linestring_ticks(mls, slk_from, slk_to, 50, 1, canvas_size_x, canvas_size_y, decimal_figures);
 	}
 	let tickmarks = ticks.map(item => [
 		[
@@ -219,7 +227,7 @@ let custom_renderer_with_SLK_ticks:(map:Map)=>RenderFunction = (map:Map) => (_pi
 export let layer_state_road = new VectorLayer({
 	source: state_road_only_vector_source,
 	style: state_road_vector_layer_style_function,
-	minZoom: 8,
+	minZoom: 6,
 });
 /**
  * Due to an irritating problem
@@ -231,5 +239,5 @@ export let get_layer_state_road_ticks = map => new VectorLayer({
 	style: new Style({
 		renderer:custom_renderer_with_SLK_ticks(map)
 	}),
-	minZoom: 12,
+	minZoom: 8,
 });

--- a/src/nickmap/layers/wmts.ts
+++ b/src/nickmap/layers/wmts.ts
@@ -1,7 +1,8 @@
 import TileLayer from "ol/layer/Tile";
 import XYZ from 'ol/source/XYZ';
+import { monkey_patch_brightness_greyscale_layer } from "./TileLayerMonkeyPatchedBrightnessGreyscale";
 
-export const layer_wmts:TileLayer<XYZ> = new TileLayer({
+export const layer_wmts = monkey_patch_brightness_greyscale_layer(new TileLayer({
     visible:false,
     source: new XYZ({})
-});
+}));

--- a/src/nickmap/nickmap.css
+++ b/src/nickmap/nickmap.css
@@ -35,20 +35,20 @@
     
 }
 
-.nickmap-status-text{
+.nickmap-status-text, .nickmap-status-selected{
     color: #000;
     text-shadow:
-    -1px -1px 1px white,
-    1px -1px 1px white,
-    -1px 1px 1px white,
-    1px 1px 1px white; 
+    -1px -1px 1px #CCC,
+    1px -1px 1px #CCC,
+    -1px 1px 1px #CCC,
+    1px 1px 1px #CCC;
 }
 .nickmap-version-text{
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     text-align: right;
-    color: #000B;
+    color: #BBBB;
 }
 
 .nickmap-status-text-warning{

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -94,11 +94,36 @@ class MapBackgroundSettings extends formattingSettings.Card {
         displayName : "Show Tile ArcGIS",
         value       : true,
     })
+
+    osm_brightness = new formattingSettings.Slider({
+        name        : "osm_brightness",
+        displayName : "Brightness",
+        description : "Controls the brightness of the background layers",
+        options     :{
+            minValue:{type:powerbi.visuals.ValidatorType.Min, value:0},
+            maxValue:{type:powerbi.visuals.ValidatorType.Max, value:100},
+        },
+        value: 50
+    });
+
+    osm_greyscale = new formattingSettings.Slider({
+        name        : "osm_greyscale",
+        displayName : "Greyscale",
+        description : "Controls the saturation of the background layers.",
+        options     :{
+            minValue:{type:powerbi.visuals.ValidatorType.Min, value:0},
+            maxValue:{type:powerbi.visuals.ValidatorType.Max, value:100},
+        },
+        value: 0
+    });
+
     slices = [
         this.url_wmts,
         this.url_wmts_show,
         this.url_tile_arcgis,
-        this.url_tile_arcgis_show
+        this.url_tile_arcgis_show,
+        this.osm_brightness,
+        this.osm_greyscale,
     ]
 }
 

--- a/src/visual.tsx
+++ b/src/visual.tsx
@@ -154,7 +154,7 @@ export class Visual implements IVisual {
         ReactDOM.render(
             <NickMap
                 host={this.host}
-                version_text = "NickMapBI 2023-02-28-4.1.1 TEST VERSION"
+                version_text = "v4.1.2 NickMapBI"
 
                 layer_arcgis_rest_url                 = {map_background_settings.url_tile_arcgis.value}
                 layer_arcgis_rest_show_initial        = {map_background_settings.url_tile_arcgis_show.value}
@@ -166,6 +166,9 @@ export class Visual implements IVisual {
                 layer_road_network_ticks_show_initial = {road_network_settings.show_ticks.value}
                 layer_road_network_state_colour       = {road_network_settings.state_road_colour.value.value}
                 layer_road_network_psp_colour         = {road_network_settings.psp_colour.value.value}
+
+                layer_osm_brightness                  = {map_background_settings.osm_brightness.value}
+                layer_osm_greyscale                   = {map_background_settings.osm_greyscale.value}
 
                 auto_zoom_initial                     = {map_behaviour_settings.auto_zoom.value}
                 controls_size                         = {map_behaviour_settings.controls_size.value}


### PR DESCRIPTION
- version changed from 4.1.1 to 4.1.2
- greyscale and brightness controll all raster layers
- improved tickmarks
- made road network show from further out
- internal refactorings of NickMap component
- improved version display
  - removed `TEST VERSION` text
- fixed removal of selection on every update
- tooltips now hide when map is moved or zoomed