### PR TITLE
Support x request

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -87,7 +87,7 @@
                 "osm_saturation"       :{"type": {"numeric":true}}
             }
         },
-        "map_behaviour": {
+        "map_behavior": {
             "properties": {
                 "auto_zoom":{"type": {"bool":true}},
                 "controls_size":{"type": {"numeric":true}},
@@ -96,6 +96,12 @@
                     {"displayName": "Collapsed", "value": "Collapsed"},
                     {"displayName": "Expanded",  "value": "Expanded"}
                 ]}}
+            }
+        },
+        "map_statusbar": {
+            "properties": {
+                "show_non_mappable_rows":{"type": {"bool":true}},
+                "show_result_count":{"type": {"bool":true}}
             }
         },
         "advanced_settings":{

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,29 @@
 # Changelog
 
+## [4.2.2] - UNRELEASED - 2023-06-22
+
+### Fixed
+
+- added `x-request-id` support when available. This will prevent processing out
+  of order responses.
+- no longer show blank tooltips when no columns in field well
+  [#49](https://github.com/thehappycheese/nickmap-bi/issues/49)
+
+### Changed
+
+- Better explanation for why rows cannot be mapped
+  [#28](https://github.com/thehappycheese/nickmap-bi/issues/28)
+- added setting to hide the number of mapped features in the status bar
+- added setting to hide warnings about unmapped rows
+  [#50](https://github.com/thehappycheese/nickmap-bi/issues/50)
+- reduced size of status bar
+- top-left controls are now collapsed by default since this seems to be the
+  preference of most users.
+
 ## [4.2.0] - 2023-04-12
 
 ### Changed
+
 - [#9](https://github.com/thehappycheese/nickmap-bi/issues/9) Tooltips now show on hover.
 - Minor improvements to controls style. Moved scale bar to top right.
 

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,7 +4,7 @@
         "displayName": "NickMap BI",
         "guid": "nickmapbi82E1C4CFA7CF45C0BC3CD8771F27FDAF",
         "visualClassName": "Visual",
-        "version": "4.2.1",
+        "version": "4.2.2",
         "description": "Map linear data on the West Australian road network (using slk_from slk_to)",
         "supportUrl": "https://github.com/thehappycheese/nickmap-bi",
         "gitHubUrl": "https://github.com/thehappycheese/nickmap-bi"

--- a/src/NickmapFeatures.tsx
+++ b/src/NickmapFeatures.tsx
@@ -1,3 +1,5 @@
+"use strict";
+
 export interface NickmapFeatureCollection {
     type: "FeatureCollection";
     features: {

--- a/src/data_types/FeatureTooltipItems.ts
+++ b/src/data_types/FeatureTooltipItems.ts
@@ -1,0 +1,8 @@
+import powerbi from "powerbi-visuals-api";
+
+
+
+export type FeatureTooltipItem = {
+    column_name: string;
+    value: powerbi.PrimitiveValue;
+};

--- a/src/data_types/NonMappableRow.tsx
+++ b/src/data_types/NonMappableRow.tsx
@@ -1,0 +1,15 @@
+import powerbi from "powerbi-visuals-api";
+import { FeatureTooltipItem } from "./FeatureTooltipItems";
+
+export interface NonMappableRow {
+    row_number:number
+    selection_id: powerbi.visuals.ISelectionId;
+    reason: string;
+    query:{
+        road:string,
+        cwy:string,
+        slk_from:number,
+        slk_to:number,
+    }
+    tooltips:FeatureTooltipItem[]
+}

--- a/src/dataview_table_helpers.ts
+++ b/src/dataview_table_helpers.ts
@@ -1,6 +1,7 @@
 import powerbi from "powerbi-visuals-api";
 import { valueFormatter } from "powerbi-visuals-utils-formattingutils";
 import { IValueFormatter } from "powerbi-visuals-utils-formattingutils/lib/src/valueFormatter";
+import { FeatureTooltipItem } from "./data_types/FeatureTooltipItems";
 
 /**
  * Unless restricted by capabilities.json,
@@ -44,11 +45,23 @@ export function dataview_table_role_column_indices__all(data_view_table:powerbi.
 }
 
 
-export type feature_tooltip_items = {
-    column_name:string,
-    value:powerbi.PrimitiveValue
-}[]
-
+/**
+ * Transforms a given PowerBI DataViewTable into an array of objects suitable for georeferencing.
+ *
+ * This function iterates over the rows of the input DataViewTable, converting each row 
+ * into an object with properties for road number, start and end SLK, offset, carriageway, colour,
+ * line width, selection_id, and tooltips. These objects can be used as input for the 
+ * batch_requests function, which georeferences these road segments into a FeatureCollection 
+ * suitable for display in OpenLayers.
+ *
+ * @param data_view_table - The DataViewTable from PowerBI that contains the input data.
+ * @param host - The PowerBI visual host, used for creating selection IDs.
+ * @param default_line_width - The default line width to use for road segments.
+ * @param default_line_color - The default line colour to use for road segments.
+ *
+ * @returns An array of objects representing road segments, suitable for input to the 
+ *          batch_requests function for georeferencing.
+ */
 export function transform_data_view(
     data_view_table:powerbi.DataViewTable,
     host:powerbi.extensibility.visual.IVisualHost,
@@ -63,7 +76,7 @@ export function transform_data_view(
     colour       : string,
     line_width   : number,
     selection_id : powerbi.visuals.ISelectionId
-    tooltips     : feature_tooltip_items
+    tooltips     : FeatureTooltipItem[]
 }[]{
     if (data_view_table.rows === undefined){
         return [];
@@ -78,14 +91,8 @@ export function transform_data_view(
     }) ?? [];
 
     for (let row_index=0;row_index<data_view_table.rows.length;row_index++){
-        // TODO: Build data integrity report
-        // if(role_columns["road_number"]===undefined || role_columns["road_number"][0]===undefined || !(typeof role_columns["road_number"][0] === "string")){
-        //     continue
-        // }
-        // if(role_columns["road_number"]===undefined || role_columns["road_number"][0]===undefined || !(typeof role_columns["road_number"][0] === "string")){
-        //     continue
-        // }
         let row = data_view_table.rows[row_index];
+
         result.push({
             road_number  :            row[role_columns["road_number"]?.[0]]?.toString() ?? "",
             slk_from     : parseFloat(row[role_columns["slk_from"   ]?.[0]] as any),

--- a/src/linref.ts
+++ b/src/linref.ts
@@ -59,6 +59,25 @@ export class BatchRequestRequestIDMismatchError extends Error { }
 
 let x_request_id_global_latest: number = 0;
 
+/**
+ * Transforms a given PowerBI DataViewTable into an array of objects suitable
+ * for georeferencing.
+ *
+ * This function iterates over the rows of the input DataViewTable, converting each row 
+ * into an object with properties for road number, start and end SLK, offset, CWY, colour,
+ * line width, selection_id, and tooltips. These objects can be used as input for the 
+ * batch_requests function, which georeferences these road segments into a FeatureCollection 
+ * suitable for display in OpenLayers.
+ *
+ * @param data_view_table - The DataViewTable from PowerBI that contains the input data.
+ * @param host - The PowerBI visual host, used for creating selection IDs.
+ * @param default_line_width - The default line width to use for road segments.
+ * @param default_line_color - The default line colour to use for road segments.
+ *
+ * @returns An array of objects representing road segments, suitable for input to the 
+ *          batch_requests function for georeferencing.
+ */
+
 export async function batch_requests(
     road_segments: {
         road_number: string,

--- a/src/nickmap/NickMap.tsx
+++ b/src/nickmap/NickMap.tsx
@@ -47,7 +47,7 @@ import { set } from 'ol/transform';
 type NickMapProps = {
     
     host:IVisualHost // good change to try context provider
-    version_text:string
+    version_node:React.ReactNode
 
     layer_arcgis_rest_url:string
     layer_arcgis_rest_show_initial:boolean
@@ -542,7 +542,7 @@ export function NickMap(props:NickMapProps){
                     }))
                 }</div>
                 <div ref={select_status_display_ref} className="nickmap-status-selected">{`Selected: ${props.selection_manager.getSelectionIds().length}`}</div>
-                <div className="nickmap-version-text" title={props.version_text}>{props.version_text}</div>
+                <div className="nickmap-version-text">{props.version_node}</div>
             </div>
             <div 
                 className='nickmap-modal-explanation'

--- a/src/nickmap/nickmap.css
+++ b/src/nickmap/nickmap.css
@@ -29,9 +29,11 @@
     right :0.3em;
     left  :0.3em;
     z-index: 9999;
-    display:grid;
-    grid-template-columns: 1fr auto auto auto;
-    gap:1em;
+    display:flex;
+    flex-direction:row;
+    justify-content: end;
+    align-items: end;
+    gap:0.5em;
     
 }
 
@@ -53,11 +55,12 @@
     max-width: 80%;
 }
 
-.nickmap-status-text, .nickmap-status-selected{
+.nickmap-status-box {
     color: #000;
     background-color:rgba(255,255,255,0.75);
-    border-radius: 4px;
-    padding:3px;
+    border-radius: 0.2em;
+    padding:0.1em 0.2em;
+    white-space: nowrap;
 }
 .nickmap-version-text{
     overflow: hidden;

--- a/src/nickmap/nickmap.css
+++ b/src/nickmap/nickmap.css
@@ -81,3 +81,20 @@
     bottom:unset;
     left:unset;
 }
+
+table.nickmap-non-mappable {
+    border: 1px solid grey;
+    border-collapse: collapse;
+    font-size: 80%;
+}
+table.nickmap-non-mappable th{
+    border-right: 1px solid grey;
+}
+table.nickmap-non-mappable th,
+table.nickmap-non-mappable td {
+    text-align: left;
+    padding: 0.1em 0.5em;
+}
+table.nickmap-non-mappable tr {
+    border: 1px solid grey;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -225,13 +225,13 @@ export class NickMapBIFormattingSettings extends formattingSettings.Model {
     line_format_settings = new LineFormatSettings();
     road_network_settings = new RoadNetworkSettings();
     map_background_settings = new MapBackgroundSettings();
-    map_behaviour_settings = new MapBehaviourSettings();
+    map_behavior_settings = new MapBehaviourSettings();
     advanced_settings = new AdvancedSettings();
     cards = [
         this.line_format_settings,
         this.road_network_settings,
         this.map_background_settings,
-        this.map_behaviour_settings,
+        this.map_behavior_settings,
         this.advanced_settings
     ]
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,21 +149,21 @@ const controls_mode_enum_options:ControlsMode[] = [
     {"displayName": "Expanded",  "value": "Expanded" }
 ]
 
-class MapBehaviourSettings extends formattingSettings.Card {
-    name = "map_behaviour";
-    displayName = "Map Behaviour";
+class MapBehaviorSettings extends formattingSettings.Card {
+    name = "map_behavior";
+    displayName = "Map Behavior";
 
     auto_zoom = new formattingSettings.ToggleSwitch({
         name        : "auto_zoom",
         displayName : "Auto Zoom (startup)",
-        description : "Controls the default behaviour when the report is first opened; Auto zoom to the extent of loaded features when slicers change.",
+        description : "Controls the default behavior when the report is first opened; Auto zoom to the extent of loaded features when slicers change.",
         value       : true,
     })
 
     controls_mode = new formattingSettings.ItemDropdown({
         name        : "controls_mode",
         displayName : "Controls (startup)",
-        value       : {value:"Expanded", displayName:"Expanded"},
+        value       : {value:"Collapsed", displayName:"Collapsed"},
         items       : controls_mode_enum_options
     })
 
@@ -182,6 +182,30 @@ class MapBehaviourSettings extends formattingSettings.Card {
         this.auto_zoom,
         this.controls_mode,
         this.controls_size
+    ]
+}
+
+class MapStatusBarSettings extends formattingSettings.Card {
+    name = "map_statusbar";
+    displayName = "Status Bar";
+
+
+    show_non_mappable_rows = new formattingSettings.ToggleSwitch({
+        name        : "show_non_mappable_rows",
+        displayName : "Show Non Mappable Rows",
+        description : "Show a warning message when some rows could not be mapped.",
+        value       : true,
+    });
+    show_result_count = new formattingSettings.ToggleSwitch({
+        name        : "show_result_count",
+        displayName : "Show Result Count",
+        description : "Show or hide the count of successfully mapped rows.",
+        value       : true,
+    });
+
+    slices = [
+        this.show_non_mappable_rows,
+        this.show_result_count
     ]
 }
 
@@ -225,13 +249,15 @@ export class NickMapBIFormattingSettings extends formattingSettings.Model {
     line_format_settings = new LineFormatSettings();
     road_network_settings = new RoadNetworkSettings();
     map_background_settings = new MapBackgroundSettings();
-    map_behavior_settings = new MapBehaviourSettings();
+    map_behavior_settings = new MapBehaviorSettings();
+    map_status_bar_settings = new MapStatusBarSettings();
     advanced_settings = new AdvancedSettings();
     cards = [
         this.line_format_settings,
         this.road_network_settings,
         this.map_background_settings,
         this.map_behavior_settings,
+        this.map_status_bar_settings,
         this.advanced_settings
     ]
 }

--- a/src/util/is_in.ts
+++ b/src/util/is_in.ts
@@ -1,0 +1,18 @@
+/**
+ * Type guard function to check if a property exists in an object.
+ * 
+ * @template T - The type of the object. Must extend object.
+ * 
+ * @param {PropertyKey} key - The property key to check.
+ * @param {T} obj - The object in which to check for the property.
+ * 
+ * @returns {boolean} - True if the property exists in the object, false otherwise.
+ * 
+ * If true, the TypeScript type of `key` is narrowed to be a keyof `T`, 
+ * indicating it exists as a property within the object `T`.
+ */
+export function is_in<T extends Object>(
+    key: PropertyKey, obj: T
+): key is keyof T {
+    return key in obj;
+}

--- a/src/visual.tsx
+++ b/src/visual.tsx
@@ -241,7 +241,7 @@ export class Visual implements IVisual {
         ReactDOM.render(
             <NickMap
                 host={this.host}
-                version_text = '<span style="color:red">v4.2.2-DEV</style> NickMapBI'
+                version_node                          = {<><span style={{color:"red"}}>v4.2.2-DEV NickMapBI</span></>}
 
                 layer_arcgis_rest_url                 = {map_background_settings.url_tile_arcgis.value}
                 layer_arcgis_rest_show_initial        = {map_background_settings.url_tile_arcgis_show.value}

--- a/src/visual.tsx
+++ b/src/visual.tsx
@@ -196,7 +196,7 @@ export class Visual implements IVisual {
                                 tooltips:input_row.tooltips
                             };
                             if(feature===null || feature===undefined){
-                                non_mappable_row.reason = "Invalid road or cwy";
+                                non_mappable_row.reason = "invalid road or cwy";
                             }else if(feature?.geometry?.coordinates && feature?.geometry?.coordinates.length === 0){
                                 if(input_row.slk_from === input_row.slk_to){
                                     non_mappable_row.reason = "slk_from = slk_to";
@@ -234,14 +234,14 @@ export class Visual implements IVisual {
         
         let map_background_settings = this.formattingSettings.map_background_settings
         let road_network_settings   = this.formattingSettings.road_network_settings
-
         let map_behavior_settings = this.formattingSettings.map_behavior_settings
+        let map_status_bar_settings = this.formattingSettings.map_status_bar_settings;
         let advanced_settings      = this.formattingSettings.advanced_settings
         
         ReactDOM.render(
             <NickMap
                 host={this.host}
-                version_node                          = {<><span style={{color:"red"}}>v4.2.2-DEV NickMapBI</span></>}
+                version_node                          = {<>v4.2.2<br/>NickMapBI</>}
 
                 layer_arcgis_rest_url                 = {map_background_settings.url_tile_arcgis.value}
                 layer_arcgis_rest_show_initial        = {map_background_settings.url_tile_arcgis_show.value}
@@ -261,6 +261,9 @@ export class Visual implements IVisual {
                 auto_zoom_initial                     = {map_behavior_settings.auto_zoom.value}
                 controls_size                         = {map_behavior_settings.controls_size.value}
                 controls_mode                         = {(map_behavior_settings.controls_mode.value as ControlsMode).value}
+
+                show_non_mappable_rows                = {map_status_bar_settings.show_non_mappable_rows.value}
+                show_result_count                     = {map_status_bar_settings.show_result_count.value}
 
                 allow_drag_box_selection              = {advanced_settings.allow_drag_box_selection.value}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "lib": [
             "es2022",
             "dom"
-        ]
+        ],
+        "strict": true
     },
     "files": [
         "./src/visual.tsx"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
         "strict": true
     },
     "files": [
-        "./src/visual.tsx"
+        "./src/visual.tsx", "src/data_types/NonMappableRow.tsx", "src/data_types/FeatureTooltipItems.ts"
     ]
 }


### PR DESCRIPTION
- added `x-request-id` support when available. This will prevent processing out
  of order responses.
  #43 
- no longer show blank tooltips when no columns in field well
  #49
- Better explanation for why rows cannot be mapped
  #28
- added setting to hide the number of mapped features in the status bar
- added setting to hide warnings about unmapped rows
  #50
- reduced size of status bar
- top-left controls are now collapsed by default since this seems to be the
  preference of most users.