### PR TITLE
Add color

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 {
     "cSpell.words": [
-		"arcgis",
-		"color",
-		"nickmap",
-		"powerbi",
-		"wmts"
-	],
+        "arcgis",
+        "color",
+        "linestring",
+        "nickmap",
+        "powerbi",
+        "wmts"
+    ],
     "json.schemas": [
 		{
 			"fileMatch": [

--- a/changelog.md
+++ b/changelog.md
@@ -1,16 +1,12 @@
 # Changelog
 
-## [4.2.2] - UNRELEASED - 2023-06-22
-
-### Fixed
+## [4.3.0] - UNRELEASED - 2023-06-22
 
 - added `x-request-id` support when available. This will prevent processing out
   of order responses.
+  [#43](https://github.com/thehappycheese/nickmap-bi/issues/43)
 - no longer show blank tooltips when no columns in field well
   [#49](https://github.com/thehappycheese/nickmap-bi/issues/49)
-
-### Changed
-
 - Better explanation for why rows cannot be mapped
   [#28](https://github.com/thehappycheese/nickmap-bi/issues/28)
 - added setting to hide the number of mapped features in the status bar

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [4.3.0] - UNRELEASED - 2023-06-22
+## [4.2.3] - UNRELEASED - 2023-06-22
+
+
+## [4.2.2] - UNRELEASED - 2023-06-22
 
 - added `x-request-id` support when available. This will prevent processing out
   of order responses.

--- a/src/nickmap/NickMap.tsx
+++ b/src/nickmap/NickMap.tsx
@@ -60,9 +60,9 @@ type NickMapProps = {
     layer_road_network_state_colour:string
     layer_road_network_psp_colour:string
 
-    layer_raster_brightness:number;
-    layer_raster_contrast:number;
-    layer_raster_saturation:number;
+    layer_raster_brightness:number
+    layer_raster_contrast:number
+    layer_raster_saturation:number
 
     auto_zoom_initial:boolean
     controls_size:number
@@ -84,7 +84,9 @@ type NickMapProps = {
     selection_manager:powerbi.extensibility.ISelectionManager
     
     tooltip_service:powerbi.extensibility.ITooltipService
-    tooltip_service_wrapper: ITooltipServiceWrapper,
+    tooltip_service_wrapper: ITooltipServiceWrapper
+
+    colour_palette_service:powerbi.extensibility.IColorPalette
 
 }
 

--- a/src/nickmap/NickMapControls.tsx
+++ b/src/nickmap/NickMapControls.tsx
@@ -38,18 +38,20 @@ export function NickMapControls (props:NickMapControlsComponentProps){
     const [zoom_to_road, set_zoom_to_road] = React.useState<string>("")
     const [show_zoomto_fail_explanation, set_show_zoomto_fail_explanation] = React.useState(false);
     const [zoom_to_slk, set_zoom_to_slk] = React.useState<number>(0)
-    const zoom_to_road_input_ref = React.useRef<HTMLInputElement>()
+    const zoom_to_road_input_ref = React.useRef<HTMLInputElement>(null)
 
     const handleSubmit = React.useCallback(
-        (event) => {
-            console.log("Active Element", document.activeElement);
+        (event:any) => {
+            if(zoom_to_road_input_ref.current===null){
+                return;
+            }
             event.preventDefault();
             set_show_zoomto_fail_explanation(false);
             props.on_zoom_to_road_slk(
                 zoom_to_road_input_ref.current.value,
                 zoom_to_slk
             );
-            zoom_to_road_input_ref.current.reportValidity();
+            zoom_to_road_input_ref.current?.reportValidity();
         },
         [props.on_zoom_to_road_slk, set_show_zoomto_fail_explanation, zoom_to_slk]
     );

--- a/src/nickmap/nicks_line_tools.ts
+++ b/src/nickmap/nicks_line_tools.ts
@@ -15,7 +15,10 @@ export function linestring_measure(line_string:NickLineString):NickMeasuredLineS
 	}else{
 		let result:[Vector2, number][] = [];
 		let total_length = 0;
-		let b:Vector2 = line_string.at(-1);
+		let b:Vector2 | undefined = line_string.at(-1);
+        if (b === undefined) {
+            return [[], 0];
+        }
 		for (let i = 0; i < line_string.length - 1; i++) {
 			let a:Vector2 = line_string[i];
 			b = line_string[i + 1];
@@ -29,24 +32,24 @@ export function linestring_measure(line_string:NickLineString):NickMeasuredLineS
 	}
 }
 
-export function linestring_direction(measured_line_string:NickMeasuredLineString, normalised_distance_along:number) {
+export function linestring_direction(measured_line_string:NickMeasuredLineString, normalized_distance_along:number) {
 	// returns the direction (as a unit vector) of a linestring segment which contains the point
 	let [points, total_length] = measured_line_string;
-	let de_normalised_distance_along = total_length * normalised_distance_along;
+	let de_normalized_distance_along = total_length * normalized_distance_along;
 	let len_so_far = 0;
-	let ab_len;
-	let ab;
+	let ab_len=1;
+	let ab = new Vector2(1,0);
 	for (let i = 0; i < points.length - 1; i++) {
 		let a;
 		[a, ab_len] = points[i];
 		let [b, _] = points[i + 1];
 		ab = b.sub(a);
 		len_so_far += ab_len;
-		if (len_so_far >= de_normalised_distance_along) {
-			return ab.copy().scalar_divide(ab_len);
+		if (len_so_far >= de_normalized_distance_along) {
+			return ab.clone().div(ab_len);
 		}
 	}
-	return ab.copy().scalar_divide(ab_len);
+	return ab.clone().div(ab_len);
 }
 
 export function linestring_ticks(
@@ -55,8 +58,8 @@ export function linestring_ticks(
 	slk_to:number,
 	minor_interval_km:number,
 	major_interval_count:number,
-	x_px,
-	y_px,
+	x_px:number,
+	y_px:number,
 	decimal_figures:number
 	) {
 

--- a/src/visual.tsx
+++ b/src/visual.tsx
@@ -38,9 +38,11 @@ export class Visual implements IVisual {
     private tooltip_service: powerbi.extensibility.ITooltipService;
     private tooltip_service_wrapper: ITooltipServiceWrapper;
 
-    constructor(options: VisualConstructorOptions) {
+    private colour_palette_service: powerbi.extensibility.IColorPalette;
 
-        if (!document || !options.element){
+    constructor(options?: VisualConstructorOptions) {
+        
+        if (!document || options===undefined || !options.element){
             throw new Error("Visual constructed without DOM???")
         }
         this.host = options.host;
@@ -51,6 +53,7 @@ export class Visual implements IVisual {
             options.host.tooltipService,
             options.element
         );
+        this.colour_palette_service = options.host.colorPalette;
         this.formattingSettingsService = new FormattingSettingsService();
         // attempt to set default settings?
         this.formattingSettings = this.formattingSettingsService.populateFormattingSettingsModel(NickMapBIFormattingSettings, []);
@@ -170,12 +173,13 @@ export class Visual implements IVisual {
                 zip_arrays(input_properties, returned_features.features).forEach(
                     ([input_row, feature], row_index)=>{
                         if (feature && feature?.geometry?.coordinates && feature?.geometry?.coordinates.length !== 0){
+                            let selection_key = input_row.selection_id.getKey();
                             features_filtered_and_coloured.features.push(
                                 {
                                     ...feature,
-                                    id : input_row.selection_id.getKey(),
+                                    id : selection_key,
                                     properties:{
-                                        colour       : input_row.colour,
+                                        colour       : input_row.colour,//this.colour_palette_service.getColor(input_row.colour).value,//input_row.colour,
                                         line_width   : input_row.line_width,
                                         selection_id : input_row.selection_id,
                                         tooltips     : input_row.tooltips,
@@ -277,6 +281,7 @@ export class Visual implements IVisual {
                 tooltip_service                       = {this.tooltip_service}
                 tooltip_service_wrapper               = {this.tooltip_service_wrapper}
 
+                colour_palette_service                 = {this.colour_palette_service}
             />,
             this.react_root
         )


### PR DESCRIPTION
v4.2.2 tag to be moved here; there were many hidden errors after switching typescript to strict mode

- added `x-request-id` support when available. This will prevent processing out
  of order responses.
  #43 
- no longer show blank tooltips when no columns in field well
  #49
- Better explanation for why rows cannot be mapped
  #28
- added setting to hide the number of mapped features in the status bar
- added setting to hide warnings about unmapped rows
  #50
- reduced size of status bar
- top-left controls are now collapsed by default since this seems to be the
  preference of most users.